### PR TITLE
Write docs to do collection and project collection

### DIFF
--- a/app/coffee/DocManager.coffee
+++ b/app/coffee/DocManager.coffee
@@ -67,6 +67,7 @@ module.exports = DocManager =
 			return callback(error) if error?
 			return callback new Errors.NotFoundError("No such project/doc: #{project_id}/#{doc_id}") if !doc?
 			MongoManager.upsertIntoDocCollection project_id, doc_id, doc.lines, doc.rev, (error) ->
+				return callback(error) if error?
 				MongoManager.markDocAsDeleted doc_id, (error) ->
 					return callback(error) if error?
 					callback()

--- a/app/coffee/MongoManager.coffee
+++ b/app/coffee/MongoManager.coffee
@@ -18,7 +18,18 @@ module.exports = MongoManager =
 
 		db.projects.update _id: ObjectId(project_id), update, callback
 
-	insertDoc: (project_id, doc_id, attributes, callback = (error) ->) ->
-		attributes._id = ObjectId(doc_id)
-		attributes.project_id = ObjectId(project_id)
-		db.docs.insert attributes, callback
+	upsertIntoDocCollection: (project_id, doc_id, lines, oldRev, callback)->
+		update =
+			$set:{}
+		update.$set["lines"] = lines
+		update.$set["project_id"] = ObjectId(project_id)
+		update.$set["rev"] = oldRev + 1
+		db.docs.update _id: ObjectId(doc_id), update, {upsert: true}, callback
+
+
+	markDocAsDeleted: (doc_id, callback)->
+		update =
+			$set: {}
+		update.$set["deleted"] = true
+		db.docs.update _id: ObjectId(doc_id), update, (err)->
+			callback(err)


### PR DESCRIPTION
- docs are written to project collection then doc collection

- deletes used to insert into doc collection, now its the same upsert
with deleted = true

- does not set delted = false for new docs as it is not needed, save space

- changed delete to be seperate update on mongo