### PR TITLE
Don't log out doc lines and ranges

### DIFF
--- a/app/coffee/DocManager.coffee
+++ b/app/coffee/DocManager.coffee
@@ -98,7 +98,7 @@ module.exports = DocManager =
 						update.lines = lines
 					if updateRanges
 						update.ranges = ranges
-					logger.log { project_id, doc_id, oldDoc: doc, update: update }, "updating doc lines and ranges"
+					logger.log { project_id, doc_id, oldDoc: doc }, "updating doc lines and ranges"
 					
 					modified = true
 					rev += 1 # rev will be incremented in mongo by MongoManager.upsertIntoDocCollection

--- a/app/coffee/HttpController.coffee
+++ b/app/coffee/HttpController.coffee
@@ -12,7 +12,7 @@ module.exports = HttpController =
 		logger.log project_id: project_id, doc_id: doc_id, "getting doc"
 		DocManager.getFullDoc project_id, doc_id, (error, doc) ->
 			return next(error) if error?
-			logger.log doc: doc, "got doc"
+			logger.log {doc_id, project_id}, "got doc"
 			if !doc?
 				res.send 404
 			else if doc.deleted && !include_deleted


### PR DESCRIPTION
We log out the doc lines here for a feeling of 'safety', but I don't recall ever actually needing to look in the log to recover anything.

If we do find we need some way to record what was written and read from Mongo here, we should explore proper data stores for this sort of thing, e.g. Mongo truncated collections, or similar. Logging to disk isn't the way to do this, as we are finding out.