### PR TITLE
 Provide hosts as environment settings and add npm run start script

### DIFF
--- a/app/coffee/RangeManager.coffee
+++ b/app/coffee/RangeManager.coffee
@@ -36,5 +36,5 @@ module.exports = RangeManager =
 	_safeObjectId: (data) ->
 		try
 			return ObjectId(data)
-		catch
+		catch error
 			return data

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -5,10 +5,10 @@ module.exports = Settings =
 	internal:
 		docstore:
 			port: 3016
-			host: "localhost"
+			host: process.env['LISTEN_ADDRESS'] or "localhost"
 
 	mongo:
-		url: 'mongodb://127.0.0.1/sharelatex'
+		url: "mongodb://#{process.env['MONGO_HOST'] or '127.0.0.1'}/sharelatex"
 
 	docstore:
 		healthCheck:

--- a/package.json
+++ b/package.json
@@ -12,29 +12,31 @@
     "start": "npm run compile:app && node app.js"
   },
   "dependencies": {
-    "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
+    "async": "~0.8.0",
+    "body-parser": "~1.0.2",
+    "coffee-script": "^1.7.1",
+    "express": "~4.1.1",
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.4.0",
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.7.1",
     "mongojs": "2.4.0",
-    "express": "~4.1.1",
-    "underscore": "~1.6.0",
-    "body-parser": "~1.0.2",
-    "async": "~0.8.0"
+    "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
-    "grunt-execute": "~0.2.1",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-shell": "~0.7.0",
-    "grunt-contrib-coffee": "~0.10.1",
-    "grunt-mocha-test": "~0.10.2",
-    "grunt": "~0.4.4",
     "bunyan": "~0.22.3",
-    "grunt-bunyan": "~0.5.0",
-    "sinon": "~3.2.1",
-    "sandboxed-module": "~0.3.0",
     "chai": "~1.9.1",
+    "grunt": "~0.4.4",
+    "grunt-bunyan": "~0.5.0",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-coffee": "~0.10.1",
+    "grunt-execute": "~0.2.1",
     "grunt-forever": "~0.4.4",
-    "request": "~2.34.0"
+    "grunt-mocha-test": "~0.10.2",
+    "grunt-shell": "~0.7.0",
+    "request": "~2.34.0",
+    "sandboxed-module": "~0.3.0",
+    "sinon": "~3.2.1"
   },
   "engines": {
     "node": "~4.2.1"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/sharelatex/docstore-sharelatex.git"
   },
+  "scripts": {
+    "compile:app": "coffee -o app/js -c app/coffee && coffee -c app.coffee",
+    "start": "npm run compile:app && node app.js"
+  },
   "dependencies": {
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.4.0",


### PR DESCRIPTION
Makes this service compatible with https://github.com/sharelatex/sharelatex-dev-environment

Allows other service's locations to be passed in via environment variables which are provided by docker-compose.

Also provides an `npm run start` script as a common entry point to all services via docker-compose.