### PR TITLE
Do not specify the node version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 
-node_js:
-    - "0.10"
-
 before_install:
     - npm install -g grunt-cli
 


### PR DESCRIPTION
So travis picks instead the version from .nvmrc

The build is currently failing because it's using an old version of node

https://travis-ci.org/sharelatex/document-updater-sharelatex/builds/329565434

If we don't specify a version in travis.yml travisci uses the one in .nvmrc.

https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions-using-.nvmrc