### PR TITLE
increase body parser limit to 64kb

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -31,8 +31,8 @@ app.get  '/project/:project_id/doc', HttpController.getAllDocs
 app.get  '/project/:project_id/ranges', HttpController.getAllRanges
 app.get  '/project/:project_id/doc/:doc_id', HttpController.getDoc
 app.get  '/project/:project_id/doc/:doc_id/raw', HttpController.getRawDoc
-# Add 16kb overhead for the JSON encoding
-app.post '/project/:project_id/doc/:doc_id', bodyParser.json(limit: Settings.max_doc_length + 16 * 1024), HttpController.updateDoc
+# Add 64kb overhead for the JSON encoding
+app.post '/project/:project_id/doc/:doc_id', bodyParser.json(limit: Settings.max_doc_length + 64 * 1024), HttpController.updateDoc
 app.del  '/project/:project_id/doc/:doc_id', HttpController.deleteDoc
 
 app.post  '/project/:project_id/archive', HttpController.archiveAllDocs


### PR DESCRIPTION
Increased to match the higher limit in web, for when the 16kb limit is not enough if the doc has too many escape characters.