### PR TITLE
also delete doc ops

### DIFF
--- a/app/coffee/HealthChecker.coffee
+++ b/app/coffee/HealthChecker.coffee
@@ -36,8 +36,9 @@ module.exports =
 						cb()
 					else
 						cb("health check lines not equal #{body.lines} != #{lines}")
+			(cb)-> 
+				db.docs.remove {_id: doc_id, project_id: project_id}, cb
+			(cb)-> 
+				db.docOps.remove {doc_id: doc_id}, cb
 		]
-		async.series jobs, (err)->
-			if err?
-				callback(err)
-			db.docs.remove {_id: doc_id, project_id: project_id}, callback
+		async.series callback


### PR DESCRIPTION
There are actually a lot more docOps than docs being generated by the health check, any off the top of your head why that might be?

![2018-10-19 at 11 52](https://user-images.githubusercontent.com/343366/47214321-6f8e8880-d395-11e8-8ef1-cb7bfc7f72a1.jpg)
