### PR TITLE
also delete doc ops

### DIFF
--- a/app/coffee/HealthChecker.coffee
+++ b/app/coffee/HealthChecker.coffee
@@ -36,8 +36,9 @@ module.exports =
 						cb()
 					else
 						cb("health check lines not equal #{body.lines} != #{lines}")
+			(cb)-> 
+				db.docs.remove {_id: doc_id, project_id: project_id}, cb
+			(cb)-> 
+				db.docOps.remove {doc_id: doc_id}, cb
 		]
-		async.series jobs, (err)->
-			if err?
-				callback(err)
-			db.docs.remove {_id: doc_id, project_id: project_id}, callback
+		async.series jobs, callback


### PR DESCRIPTION
Once this is live the data will be stable, I will run a big mongo export query on the CI data set next week to find all the health check docs:

`db.docs.find( { $and: [ {lines: { $size: 2}}, {lines: "smoke test - delete me" }] } )`

I can then use these doc ids todo a delete in the doc ops collection and the docs collection rather than expensive query on the primary. 